### PR TITLE
Keep the pilot in the seat

### DIFF
--- a/Client/Assets/Scripts/ZeroGravity/Objects/MyPlayer.cs
+++ b/Client/Assets/Scripts/ZeroGravity/Objects/MyPlayer.cs
@@ -306,6 +306,19 @@ namespace ZeroGravity.Objects
 				}
 
 				base.LockedToTrigger = value;
+
+				if (FpsController != null)
+				{
+					if (value is SceneTriggerShipControl)
+					{
+						FpsController.LockPlayerToPoint(locked: true, value.transform);
+					}
+					else
+					{
+						FpsController.LockPlayerToPoint(locked: false);
+						transform.SetParent(null, worldPositionStays: true);
+					}
+				}
 			}
 		}
 
@@ -2945,6 +2958,11 @@ namespace ZeroGravity.Objects
 
 		public void ToggleRagdoll(bool? enabled = null)
 		{
+			if (LockedToTrigger != null && (enabled ?? !_isRagdolled))
+			{
+				return;
+			}
+
 			if (enabled.HasValue)
 			{
 				_isRagdolled = enabled.Value;


### PR DESCRIPTION
Sitting in a pilot seat and turning the ship leaves the avatar's body floating free of the chair
while the view stays where it should. Two causes, both client side, eighteen lines in `MyPlayer.cs`.

### The seat lock is never engaged

`MyCharacterController.LockPlayerToPoint` already does this job — it parents the player to a point
and eases them onto it, and `Update` drives it every frame while `_isLockedToPoint`. Nothing ever
switched it on. Logged once per movement message while sitting in the pilot seat:

```
lockedToPoint False   attachPoint none   trigger PilotingTrigger   sameObject True
```

So nothing held the body. Measured against the ship over ten seconds of turning, it drifted about
**one metre and six degrees** out of the chair, and eventually left the room trigger — at which point
`TransitionTriggerHelper` called `ExitVessel` and the client wrapped the seated player in a `Pivot`.
That is where the "ejected from the ship while piloting" behaviour comes from; `ExitVessel` fired
four times in one session while `LockedToTrigger` was `PilotingTrigger`.

It is engaged **only for `SceneTriggerShipControl`**. `LockedToTrigger` is set for every interactable,
and locking to all of them drags the player into displays, through hulls, and sometimes into lethal
geometry — found the hard way. Anything else releases the lock and unparents, because
`LockPlayerToPoint(false)` clears its own flag but leaves the parent it set, so a player who stands up
otherwise stays welded to the chair.

### A strapped-in player is ragdolled

`MyCharacterController` ragdolls when `Vector3.Angle(transform.up, -GravityDirection) > 40`. Turning
the ship turns the room's gravity, while a seated player's up does not follow, so the game concludes
they have fallen over. Logged while seated:

```
ragdoll True   headParent Neck   bodyToHead 1.966   bodyToHips 2.455   headToHips 0.635
```

and the skeleton stretched as it went — head to hips grew from **0.63 m to 1.08 m**. `ToggleRagdoll`
now refuses to enable while `LockedToTrigger != null`; disabling still passes, so a player who sits
down already ragdolled is cleared normally.

### Verified

Played against a local server and Nakama, on a clean world. Sitting, turning the ship hard and at
length, standing up, sitting again: the body stays in the chair, `lockedToPoint True` with the
attach point set, `ragdoll False`, and the skeleton distances hold to the millimetre. Displays and
panels behave as before.

Ship controls themselves are still wrong — the ship jumps about once a second while steering and
freezes if the input is pushed harder. Not touched here; that looks server side and is next.

Five other explanations were tried and killed by measurement before this one: the movement smoothing
constants, the anchor being allowed to rotate, the rotation being sent in the wrong frame, a detached
geometry root, and the model separating from the body. The skeleton is welded to the transform in
every sample (`modelRotVsBody (0,0,0)`), so nothing comes apart inside the avatar — seeing your own
body without a head is just the first-person head mesh being hidden from your own camera.
